### PR TITLE
Append trailing slash to Bower classpath location

### DIFF
--- a/dandelion-core/src/main/java/com/github/dandelion/core/bundle/loader/support/BowerPreLoader.java
+++ b/dandelion-core/src/main/java/com/github/dandelion/core/bundle/loader/support/BowerPreLoader.java
@@ -272,8 +272,9 @@ public class BowerPreLoader extends AbstractBundlePreLoader {
             Map<String, String> locations = new HashMap<String, String>();
             switch (locationType) {
             case classpath:
+               String classpathLocation = !bowerComponentsLocation.endsWith("/") ? bowerComponentsLocation + "/" : bowerComponentsLocation;
                locations.put(ClasspathLocator.LOCATION_KEY,
-                     bowerComponentsLocation.replace(ClasspathResourceScanner.PREFIX, "") + bowerConf.getName() + "/"
+                       classpathLocation.replace(ClasspathResourceScanner.PREFIX, "") + bowerConf.getName() + "/"
                            + mainAsset);
                break;
             case file:


### PR DESCRIPTION
Hi @tduchateau,

I ran into a small bug when trying to use the Bower integration with a classpath location for bower_components.

In my dandelion.properties, I have set:
`bower.components.location=classpath:assets/bower_components`

However, the asset links which were getting generated in the HTML output looked like:
`<script src="assets/bower_componentsbootstrap/dist/js/bootstrap.js">`

That is, it was missing the trailing slash between the bower_components directory and the bundle name. I tried putting a trailing slash on bower.components.location, but that prevented *ClasspathResourceScanner.findResourcePaths* from finding the bundles.