### PR TITLE
[Work In Progress] Use UTF-8 for reading of the JS templates

### DIFF
--- a/dandelion-thymeleaf/src/main/java/com/github/dandelion/thymeleaf/web/handler/impl/ProcessJsPostHandler.java
+++ b/dandelion-thymeleaf/src/main/java/com/github/dandelion/thymeleaf/web/handler/impl/ProcessJsPostHandler.java
@@ -84,6 +84,7 @@ public class ProcessJsPostHandler extends AbstractHandlerChain {
       JsTemplateResolver templateResolver = new JsTemplateResolver();
       templateResolver.setTemplateMode(DandelionTemplateModeHandlers.TEMPLATEMODE_DANDELION_JS);
       templateResolver.setCacheable(false);
+      templateResolver.setCharacterEncoding("UTF-8");
 
       templateEngine = new TemplateEngine();
       templateEngine.addTemplateModeHandler(DandelionTemplateModeHandlers.DANDELION_JS);


### PR DESCRIPTION
I've debugged the issue https://github.com/dandelion/dandelion-datatables/issues/300 and discovered that Thymeleaf reader creates the problem here. It will use the "system default" encoding instead of UTF-8 while preparing the postprocessed templates. It can be fixed with directly specifying the encoding of the JS assets.

_(I've signed the ICLA just before creating the PR if that matters.)_
